### PR TITLE
localAdditionalConfig should be usable alone.

### DIFF
--- a/eclipse-settings-maven-plugin/src/main/java/org/eclipse/scout/mojo/eclipse/settings/ProjectSettingsConfigurator.java
+++ b/eclipse-settings-maven-plugin/src/main/java/org/eclipse/scout/mojo/eclipse/settings/ProjectSettingsConfigurator.java
@@ -131,7 +131,7 @@ public class ProjectSettingsConfigurator extends AbstractMojo {
   }
 
   private boolean configureEclipseMeta() throws IOException, MojoExecutionException {
-    if (additionalConfig == null || additionalConfig.length <= 0) {
+    if ((additionalConfig == null || additionalConfig.length <= 0) && (localAdditionalConfig == null || localAdditionalConfig.length <= 0)) {
       LOGGER.warn("No settings specified.");
       return false;
     }


### PR DESCRIPTION
It seems that if you only set `localAdditionalConfig` config is never applied.
We get a `No settings specified.`

This PR aims to fix that.