### PR TITLE
Do not stop if we failed to copy a file

### DIFF
--- a/eclipse-settings-maven-plugin/src/main/java/org/eclipse/scout/mojo/eclipse/settings/ProjectSettingsConfigurator.java
+++ b/eclipse-settings-maven-plugin/src/main/java/org/eclipse/scout/mojo/eclipse/settings/ProjectSettingsConfigurator.java
@@ -212,8 +212,7 @@ public class ProjectSettingsConfigurator extends AbstractMojo {
         }
         updatedFiles.add(target);
       } catch (final IOException e) {
-        throw new MojoExecutionException(String.format("Unable to copy %s to %s", location, target.getAbsolutePath()),
-            e);
+        LOGGER.warn("Unable to copy {} to {} caused by {}", location, target.getAbsolutePath(), e.getMessage());
       } finally {
         for (final File file : updatedFiles) {
           buildContext.refresh(file);


### PR DESCRIPTION
This is clearly not the good solution to my problem but I'm cheating by opening a PR to workaround that issue tab is not activated on this project :sweat_smile: ...

My problem I have parent maven project (which is not a java project) where I configure my localAdditionalConfig and I want to apply this config to all maven children (which are java project)

See https://github.com/eclipse/leshan/blob/eclipse_mvn_setting/pom.xml#L325

The issue is that currently `eclipse-settings-maven-plugin` will failed on the parent project as : 
```
Unable to copy ../eclipse/settings/org.eclipse.jdt.core.prefs to /home/USER/git/leshan-test/.settings/org.eclipse.jdt.core.prefs caused by /home/USER/git/leshan-test/../eclipse/settings/org.eclipse.jdt.core.prefs (Not a file or a directory)
```

So instead of raising an exception I add a log. This works but this is not so clean.
Any idea about what could be the right way to do ? :pray: 